### PR TITLE
Utilizar variables de entorno en el front y en el back

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,18 @@ cd backend
 mvn clean install
 ```
 
+### Variables de entorno
+Copiar `.env.example` a .env
+```env
+MONGODB_URI="mongodb://<user>:<pass>@<host>:<port>/<db>"
+REDIS_HOST="<redis-host>"
+REDIS_PORT="<redis-port>"
+
+# Los siguientes aplican cuando se setea el profile en 'docker'
+MONGODB_URI_DOCKER="mongodb://<user>:<pass>@<host>:<port>/<db>"
+REDIS_HOST_DOCKER="<redis-host>"
+```
+
 ### Ejecución
 
 Desde Powershell:
@@ -118,6 +130,13 @@ Una vez ejecutado el server, dirigirse a: http://localhost:8080/swagger
 ```shell
 cd frontend
 npm install // una sola vez
+```
+
+### Variables de entorno
+Copiar `.env.example` a .env
+
+```env
+VITE_BACKEND_BASE_URL="http://localhost:8080"
 ```
 
 ### Ejecución

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -10,3 +10,4 @@ Dockerfile
 .DS_Store
 *.iml
 .idea
+.env

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,1 +1,5 @@
-
+MONGODB_URI="<uri>"
+REDIS_HOST="localhost"
+REDIS_PORT="6379"
+DOCKER_MONGODB_URI="<uri>"
+DOCKER_REDIS_HOST="redis"

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -150,7 +150,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <optional>true</optional>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Fuzzy Search -->

--- a/backend/src/main/resources/application-docker.properties
+++ b/backend/src/main/resources/application-docker.properties
@@ -1,4 +1,4 @@
 # Configuracion para entorno Docker
 # MongoDB y Redis usando nombres de servicios Docker
-spring.data.mongodb.uri=mongodb://nraboy:password1234@mongodb:27017/eventos_DB?authSource=admin
-spring.data.redis.host=redis
+spring.data.mongodb.uri=${MONGODB_URI_DOCKER}
+spring.data.redis.host=${REDIS_HOST_DOCKER}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -4,7 +4,7 @@ springdoc.api-docs.path=/v3/api-docs
 springdoc.swagger-ui.path=/swagger-ui.html
 springdoc.swagger-ui.operationsSorter=method
 # MongoDB (default: localhost para desarrollo local)
-spring.data.mongodb.uri=mongodb://nraboy:password1234@localhost:27017/eventos_DB?authSource=admin
+spring.data.mongodb.uri=${MONGODB_URI}
 spring.threads.virtual.enabled=true
 spring.data.mongodb.auto-index-creation=true
 # JWT
@@ -12,8 +12,8 @@ app.session.minutes=60
 #redis
 #redis TODO: ver si no deberiamos ponerle clave o algo
 spring.session.store-type=redis
-spring.data.redis.host=localhost
-spring.data.redis.port=6379
+spring.data.redis.host=${REDIS_HOST:localhost}
+spring.data.redis.port=${REDIS_PORT:6379}
 spring.data.redis.timeout=5000
 # Spring session
 spring.session.timeout=30m

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
     ports:
       - "27017:27017"
     environment:
-      MONGO_INITDB_ROOT_USERNAME: fveiga
+      MONGO_INITDB_ROOT_USERNAME: nraboy
       MONGO_INITDB_ROOT_PASSWORD: password1234
     restart: unless-stopped
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       context: ./backend
       dockerfile: Dockerfile
     container_name: eventos-backend
-    env_file: .env # TODO: creo que las claves tendrían que ir en este archivo .env, que no se sube al repo
+    env_file: ./backend/.env 
     environment:
       - JWT_SECRET=${JWT_SECRET}
       - SPRING_PROFILES_ACTIVE=docker
@@ -38,8 +38,7 @@ services:
     depends_on:
       eventos-backend:
         condition: service_healthy
-    environment:
-      - VITE_API_URL=http://localhost:8080
+    env_file: ./frontend/.env
 
   mongodb:
     image: mongodb/mongodb-community-server
@@ -47,7 +46,7 @@ services:
     ports:
       - "27017:27017"
     environment:
-      MONGO_INITDB_ROOT_USERNAME: nraboy
+      MONGO_INITDB_ROOT_USERNAME: fveiga
       MONGO_INITDB_ROOT_PASSWORD: password1234
     restart: unless-stopped
     networks:

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL="http://localhost:8080"


### PR DESCRIPTION
Se agregaron las variables de entorno en el back
```
# Para desarrollo local
MONGODB_URI=""
REDIS_HOST=""
REDIS_PORT=""

# Cuando se levanta el back con docker-compose
MONGODB_URI_DOCKER=""
REDIS_HOST_DOCKER=""
```
Y en el front
```
VITE_API_BASE_URL="<url-del-back>"
```

Esto requiere que se haga una copia de los .env.example en el back y en el front antes de correrlos